### PR TITLE
Impl Clone for Proj

### DIFF
--- a/src/datum_params.rs
+++ b/src/datum_params.rs
@@ -8,7 +8,7 @@ use crate::nadgrids::NadGrids;
 use crate::parse::FromStr;
 
 /// Datum parameters
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Clone, Debug, PartialEq)]
 pub(crate) enum DatumParams {
     ToWGS84_0,
     ToWGS84_3(f64, f64, f64),

--- a/src/datum_transform.rs
+++ b/src/datum_transform.rs
@@ -34,7 +34,7 @@ const SRS_WGS84_SEMIMINOR: f64 = 6356752.314;
 const SRS_WGS84_ES: f64 = 0.0066943799901413165;
 
 /// Hold datum Informations
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Datum {
     params: DatumParams,
     pub a: f64,

--- a/src/math/gauss.rs
+++ b/src/math/gauss.rs
@@ -34,7 +34,7 @@ fn srat(esinp: f64, ratexp: f64) -> f64 {
     ((1. - esinp) / (1. + esinp)).powf(ratexp)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Gauss {
     c: f64,
     k: f64,

--- a/src/nadgrids/mod.rs
+++ b/src/nadgrids/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use grid::{Grid, GridId};
 ///
 /// Returned from the sequence
 /// of nadgrids from projstring definition
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NadGrids(Vec<GridRef>);
 
 impl PartialEq for NadGrids {

--- a/src/proj.rs
+++ b/src/proj.rs
@@ -29,7 +29,7 @@ pub enum ProjType {
 
 /// A Proj object hold informations and parameters
 /// for a projection
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct ProjData {
     pub(crate) ellps: Ellipsoid,
     pub(crate) axis: Axis,
@@ -62,6 +62,7 @@ pub(crate) struct ProjData {
 /// // Create latlon stub projection with ellipsoid "GRS80"
 /// let geo = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
 /// ```
+#[derive(Clone)]
 pub struct Proj {
     datum: Datum,
     geoc: bool,

--- a/src/projections/aea.rs
+++ b/src/projections/aea.rs
@@ -51,7 +51,7 @@ fn phi1_inv(qs: f64, e: f64, one_es: f64) -> Result<f64> {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct Projection {
     e: f64,
     one_es: f64,

--- a/src/projections/estmerc.rs
+++ b/src/projections/estmerc.rs
@@ -15,7 +15,7 @@ use crate::math::{
 use crate::parameters::ParamList;
 use crate::proj::ProjData;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Ell {
     k0: f64,
     es: f64,
@@ -24,14 +24,14 @@ pub(crate) struct Ell {
     en: Enfn,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Sph {
     phi0: f64,
     esp: f64,
     ml0: f64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Projection {
     Ell(Ell),
     Sph(Sph),

--- a/src/projections/etmerc.rs
+++ b/src/projections/etmerc.rs
@@ -98,7 +98,7 @@ fn clens(a: &Coeffs, arg_r: f64) -> f64 {
     arg_r.sin() * hr
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     Qn: f64,     // Merid. quad., scaled to the projection
     Zb: f64,     // Radius vector in polar coord. systems

--- a/src/projections/geocent.rs
+++ b/src/projections/geocent.rs
@@ -10,7 +10,7 @@ use crate::proj::{ProjData, ProjType};
 // Projection stub
 super::projection! { geocent, cart }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {}
 
 impl Projection {

--- a/src/projections/laea.rs
+++ b/src/projections/laea.rs
@@ -17,7 +17,7 @@ use crate::proj::ProjData;
 // Projection stub
 super::projection! { laea }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Projection {
     El(EProj),
     Sp(SProj),
@@ -63,7 +63,7 @@ impl Projection {
 
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum EMode {
     N_POLE,
     S_POLE,
@@ -83,7 +83,7 @@ enum EMode {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct EProj {
     phi0: f64,
     e: f64,
@@ -263,7 +263,7 @@ impl EProj {
 
 #[allow(non_camel_case_types)]
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum SMode {
     N_POLE,
     S_POLE,
@@ -271,7 +271,7 @@ enum SMode {
     OBLIQ { sinb1: f64, cosb1: f64 },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct SProj {
     phi0: f64,
     mode: SMode,

--- a/src/projections/latlong.rs
+++ b/src/projections/latlong.rs
@@ -11,7 +11,7 @@ use crate::proj::{ProjData, ProjType};
 // Projection stub
 super::projection! { latlong, longlat }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {}
 
 impl Projection {

--- a/src/projections/lcc.rs
+++ b/src/projections/lcc.rs
@@ -24,7 +24,7 @@ use crate::proj::ProjData;
 // Projection stub
 super::projection! { lcc }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     n: f64,
     rho0: f64,

--- a/src/projections/merc.rs
+++ b/src/projections/merc.rs
@@ -17,7 +17,7 @@ use crate::math::{
 use crate::parameters::ParamList;
 use crate::proj::ProjData;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     is_ellps: bool,
     k0: f64,

--- a/src/projections/mod.rs
+++ b/src/projections/mod.rs
@@ -26,6 +26,7 @@ pub(crate) type ProjFn = fn(&ProjParams, f64, f64, f64) -> Result<(f64, f64, f64
 
 /// Setup: returned by the init() function
 /// Order of members: (params, inverse, forward)
+#[derive(Clone)]
 pub(crate) struct ProjDelegate(ProjParams, ProjFn, ProjFn, bool, bool);
 
 impl ProjDelegate {
@@ -146,7 +147,7 @@ macro_rules! declare_projections {
         )+
         ];
         #[allow(non_camel_case_types)]
-        #[derive(Debug)]
+        #[derive(Debug, Clone)]
         pub(crate) enum ProjParams {
             $(
                 $name($name::Projection),

--- a/src/projections/moll.rs
+++ b/src/projections/moll.rs
@@ -20,7 +20,7 @@ use crate::proj::ProjData;
 // Projection stub
 super::projection! { moll, wag4, wag5 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     c_x: f64,
     c_y: f64,

--- a/src/projections/somerc.rs
+++ b/src/projections/somerc.rs
@@ -16,7 +16,7 @@ use crate::proj::ProjData;
 // Projection stub
 super::projection! { somerc }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     e: f64,
     rone_es: f64,

--- a/src/projections/stere.rs
+++ b/src/projections/stere.rs
@@ -50,7 +50,7 @@ use Mode::*;
 // Projection stub
 super::projection! { stere, ups }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     mode: Mode,
     e: f64,

--- a/src/projections/sterea.rs
+++ b/src/projections/sterea.rs
@@ -13,7 +13,7 @@ use crate::proj::ProjData;
 // Projection stub
 super::projection! { sterea }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Projection {
     k0: f64,
     phic0: f64,

--- a/src/projections/tmerc.rs
+++ b/src/projections/tmerc.rs
@@ -17,7 +17,7 @@ use crate::projections::{estmerc, etmerc};
 // Projection stub
 super::projection! { tmerc }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum Projection {
     Exact(etmerc::Projection),
     Approx(estmerc::Projection),


### PR DESCRIPTION
This enables users to reuse `Proj` without parsing from a string every time.