### PR TITLE
Add support for `geo-types` geometry transforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## Unreleased
 
+### Added
+
+* `Transform` implementations.
+    - https://github.com/3liz/proj4rs/pull/6
+    - Implement for a 2-tuple.
+    - Implement for the `geo-types` geometries, them being placed behind a `geo-types` feature flag.
+
+### Changed
+
+* `Transform` trait signature.
+    - https://github.com/3liz/proj4rs/pull/6
+    - Alias `FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>` behind a `TransformClosure`
+    - `transform_coordinates()` takes a mutable reference to `f`, making it easier to layer `Transform` implementations.
 
 ## 0.1.1 - 2023-09-07
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ exclude = [
 thiserror = "1.0"
 lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true  }
+geo-types = { version = "0.7", optional = true  }
 
 [dev-dependencies]
 approx = "0.5"
@@ -43,6 +44,7 @@ crate_type = ["cdylib", "rlib"]
 [features]
 default = ["multi-thread"]
 multi-thread = ["lazy_static"]
+geo-types = ["dep:geo-types"]
 logging = ["log"]
 local_tests = []
 wasm-strict = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ thiserror = "1.0"
 lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true  }
 # TEMP:
-geo-types = { optional = true, git = "https://github.com/gibbz00/geo", branch = "polygon_try_mut" }
+# Relies on unreleased https://github.com/georust/geo/pull/1071 (as of 2023-09-30).
+geo-types = { optional = true, git = "https://github.com/georust/geo" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,8 @@ exclude = [
 thiserror = "1.0"
 lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true  }
-# TEMP: https://github.com/georust/geo/pull/1065
-# geo-types = { version = "0.7", optional = true  }
-geo-types = { optional = true, git = "https://github.com/gibbz00/geo", branch = "pub_polygon" }
+# TEMP:
+geo-types = { optional = true, git = "https://github.com/gibbz00/geo", branch = "polygon_try_mut" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ exclude = [
 thiserror = "1.0"
 lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true  }
-geo-types = { version = "0.7", optional = true  }
+# TEMP: https://github.com/georust/geo/pull/1065
+# geo-types = { version = "0.7", optional = true  }
+geo-types = { optional = true, git = "https://github.com/gibbz00/geo", branch = "pub_polygon" }
 
 [dev-dependencies]
 approx = "0.5"

--- a/benches/bench_proj.rs
+++ b/benches/bench_proj.rs
@@ -2,11 +2,8 @@
 //! Compare loop vs  try_fold
 //!
 //!
-use proj4rs::errors::{Error, Result};
 use proj4rs::proj::Proj;
-use proj4rs::transform::{transform, Transform};
-
-use std::ops::ControlFlow::*;
+use proj4rs::transform::transform;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -18,6 +18,19 @@ impl Transform for (f64, f64, f64) {
     }
 }
 
+//
+// Transform a 2-tuple
+//
+impl Transform for (f64, f64) {
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
+    where
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
+    {
+        (self.0, self.1) = f(self.0, self.1, 0.).map(|(x, y, _)| (x, y))?;
+        Ok(())
+    }
+}
+
 /// Transform a 3-tuple
 ///
 /// ```rust
@@ -105,6 +118,6 @@ impl Transform for [(f64, f64)] {
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         self.iter_mut()
-            .try_for_each(|(x, y)| f(*x, *y, 0.).map(|xyz| (*x, *y, _) = xyz))
+            .try_for_each(|xy| xy.transform_coordinates(f))
     }
 }

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -6,16 +6,13 @@ pub mod geo_types;
 
 use crate::errors::Result;
 use crate::proj::Proj;
-use crate::transform::{transform, Transform};
+use crate::transform::{transform, Transform, TransformClosure};
 
 //
 // Transform a 3-tuple
 //
 impl Transform for (f64, f64, f64) {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         (self.0, self.1, self.2) = f(self.0, self.1, self.2)?;
         Ok(())
     }
@@ -25,10 +22,7 @@ impl Transform for (f64, f64, f64) {
 // Transform a 2-tuple
 //
 impl Transform for (f64, f64) {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         (self.0, self.1) = f(self.0, self.1, 0.).map(|(x, y, _)| (x, y))?;
         Ok(())
     }
@@ -103,10 +97,7 @@ pub fn transform_xy(src: &Proj, dst: &Proj, x: f64, y: f64) -> Result<(f64, f64)
 // Transform an array of 3-tuple:
 //
 impl Transform for [(f64, f64, f64)] {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         self.iter_mut()
             .try_for_each(|xyz| xyz.transform_coordinates(f))
     }
@@ -116,10 +107,7 @@ impl Transform for [(f64, f64, f64)] {
 // Transform an array of 2-tuple:
 //
 impl Transform for [(f64, f64)] {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         self.iter_mut()
             .try_for_each(|xy| xy.transform_coordinates(f))
     }

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -1,6 +1,9 @@
 //!
 //! Transform adaptors
 //!
+#[cfg(feature = "geo-types")]
+pub mod geo_types;
+
 use crate::errors::Result;
 use crate::proj::Proj;
 use crate::transform::{transform, Transform};

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -92,7 +92,7 @@ impl Transform for [(f64, f64, f64)] {
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         self.iter_mut()
-            .try_for_each(|(x, y, z)| f(*x, *y, *z).map(|xyz| (*x, *y, *z) = xyz))
+            .try_for_each(|xyz| xyz.transform_coordinates(f))
     }
 }
 

--- a/src/adaptors.rs
+++ b/src/adaptors.rs
@@ -9,7 +9,7 @@ use crate::transform::{transform, Transform};
 // Transform a 3-tuple
 //
 impl Transform for (f64, f64, f64) {
-    fn transform_coordinates<F>(&mut self, mut f: F) -> Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
@@ -87,7 +87,7 @@ pub fn transform_xy(src: &Proj, dst: &Proj, x: f64, y: f64) -> Result<(f64, f64)
 // Transform an array of 3-tuple:
 //
 impl Transform for [(f64, f64, f64)] {
-    fn transform_coordinates<F>(&mut self, mut f: F) -> Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
@@ -100,7 +100,7 @@ impl Transform for [(f64, f64, f64)] {
 // Transform an array of 2-tuple:
 //
 impl Transform for [(f64, f64)] {
-    fn transform_coordinates<F>(&mut self, mut f: F) -> Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -44,6 +44,13 @@ impl Transform for LineString {
     }
 }
 
+impl Transform for MultiLineString {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        self.iter_mut()
+            .try_for_each(|line_string| line_string.transform_coordinates(f))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;
@@ -99,6 +106,20 @@ mod tests {
         transform_helper(&mut line_string);
         assert_cord_eq(-COORD_1, line_string.0[0]);
         assert_cord_eq(COORD_1, line_string.0[1]);
+    }
+
+    #[test]
+    fn transforms_multi_line_string() {
+        let mut multi_line_string = MultiLineString::new(vec![
+            LineString::new(vec![-COORD_0, COORD_0]),
+            LineString::new(vec![-COORD_0, COORD_0]),
+        ]);
+        transform_helper(&mut multi_line_string);
+
+        multi_line_string.into_iter().for_each(|line_string| {
+            assert_cord_eq(-COORD_1, line_string.0[0]);
+            assert_cord_eq(COORD_1, line_string.0[1]);
+        })
     }
 
     fn transform_helper<T: Transform>(geometry: &mut T) {

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -41,7 +41,6 @@ impl Transform for Line {
 
 #[cfg(test)]
 mod tests {
-
     use approx::assert_abs_diff_eq;
 
     use crate::{transform::transform, Proj};
@@ -61,24 +60,14 @@ mod tests {
     #[test]
     fn transforms_point() {
         let mut point = Point::from(COORD_0);
-
-        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
-        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
-
-        transform(&from, &to, &mut point).unwrap();
-
+        transform_helper(&mut point);
         assert_cord_eq(COORD_1, point.0)
     }
 
     #[test]
     fn transforms_multi_point() {
         let mut multi_point: MultiPoint = (0..10).map(|_| Point::from(COORD_0)).collect();
-
-        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
-        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
-
-        transform(&from, &to, &mut multi_point).unwrap();
-
+        transform_helper(&mut multi_point);
         multi_point
             .iter()
             .for_each(|point| assert_cord_eq(COORD_1, point.0));
@@ -87,14 +76,15 @@ mod tests {
     #[test]
     fn transforms_line() {
         let mut line = Line::new(-COORD_0, COORD_0);
-
-        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
-        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
-
-        transform(&from, &to, &mut line).unwrap();
-
+        transform_helper(&mut line);
         assert_cord_eq(-COORD_1, line.start);
         assert_cord_eq(COORD_1, line.end);
+    }
+
+    fn transform_helper<T: Transform>(geometry: &mut T) {
+        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
+        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
+        transform(&from, &to, geometry).unwrap();
     }
 
     fn assert_cord_eq(expected_coord: Coord, actual_coord: Coord) {

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -35,23 +35,29 @@ mod tests {
 
     use super::*;
 
+    const X_0: f64 = 2.;
+    const Y_0: f64 = 1.;
+    const X_1: f64 = 222650.79679758527;
+    const Y_1: f64 = 110642.22941193319;
+    const EPS: f64 = 1.0e-10;
+
     #[test]
     fn transforms_point() {
-        let mut point = Point::from((2.0f64.to_radians(), 1.0f64.to_radians()));
+        let mut point = Point::from((X_0.to_radians(), Y_0.to_radians()));
 
         let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
         let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
 
         transform(&from, &to, &mut point).unwrap();
 
-        assert_abs_diff_eq!(point.x(), 222650.79679758527, epsilon = 1.0e-10);
-        assert_abs_diff_eq!(point.y(), 110642.22941193319, epsilon = 1.0e-10);
+        assert_abs_diff_eq!(point.x(), X_1, epsilon = EPS);
+        assert_abs_diff_eq!(point.y(), Y_1, epsilon = EPS);
     }
 
     #[test]
     fn transforms_multi_point() {
         let mut multi_point: MultiPoint = (0..10)
-            .map(|_| Point::from((2.0f64.to_radians(), 1.0f64.to_radians())))
+            .map(|_| Point::from((X_0.to_radians(), Y_0.to_radians())))
             .collect();
 
         let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
@@ -60,8 +66,8 @@ mod tests {
         transform(&from, &to, &mut multi_point).unwrap();
 
         multi_point.iter().for_each(|point| {
-            assert_abs_diff_eq!(point.x(), 222650.79679758527, epsilon = 1.0e-10);
-            assert_abs_diff_eq!(point.y(), 110642.22941193319, epsilon = 1.0e-10);
+            assert_abs_diff_eq!(point.x(), X_1, epsilon = EPS);
+            assert_abs_diff_eq!(point.y(), Y_1, epsilon = EPS);
         });
     }
 }

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -1,11 +1,11 @@
 use geo_types::geometry::*;
 
-use crate::transform::Transform;
+use crate::{errors::Result, transform::Transform};
 
 impl Transform for Coord {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
-        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         let mut xy = (self.x, self.y);
         (&mut xy).transform_coordinates(f)?;
@@ -15,18 +15,18 @@ impl Transform for Coord {
 }
 
 impl Transform for Point {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
-        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         self.0.transform_coordinates(f)
     }
 }
 
 impl Transform for MultiPoint {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
-        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         self.iter_mut()
             .try_for_each(|point| point.transform_coordinates(f))
@@ -34,9 +34,9 @@ impl Transform for MultiPoint {
 }
 
 impl Transform for Line {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
-        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         let (mut start, mut end) = self.points();
         start.transform_coordinates(f)?;
@@ -47,9 +47,9 @@ impl Transform for Line {
 }
 
 impl Transform for LineString {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
-        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
     {
         self.coords_mut()
             .try_for_each(|coord| coord.transform_coordinates(f))

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -46,6 +46,16 @@ impl Transform for Line {
     }
 }
 
+impl Transform for LineString {
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    where
+        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+    {
+        self.coords_mut()
+            .try_for_each(|coord| coord.transform_coordinates(f))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;
@@ -93,6 +103,14 @@ mod tests {
         transform_helper(&mut line);
         assert_cord_eq(-COORD_1, line.start);
         assert_cord_eq(COORD_1, line.end);
+    }
+
+    #[test]
+    fn transforms_line_string() {
+        let mut line_string = LineString::new(vec![-COORD_0, COORD_0]);
+        transform_helper(&mut line_string);
+        assert_cord_eq(-COORD_1, line_string.0[0]);
+        assert_cord_eq(COORD_1, line_string.0[1]);
     }
 
     fn transform_helper<T: Transform>(geometry: &mut T) {

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -78,6 +78,14 @@ impl Transform for Rect {
     }
 }
 
+impl Transform for Triangle {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        self.0.transform_coordinates(f)?;
+        self.1.transform_coordinates(f)?;
+        self.2.transform_coordinates(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -60,6 +60,13 @@ impl Transform for Polygon {
     }
 }
 
+impl Transform for MultiPolygon {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        self.iter_mut()
+            .try_for_each(|polygon| polygon.transform_coordinates(f))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -1,4 +1,4 @@
-use geo_types::Point;
+use geo_types::geometry::*;
 
 use crate::transform::Transform;
 
@@ -13,6 +13,16 @@ impl Transform for Point {
         self.set_y(xy.1);
 
         Ok(())
+    }
+}
+
+impl Transform for MultiPoint {
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    where
+        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+    {
+        self.iter_mut()
+            .try_for_each(|point| point.transform_coordinates(f))
     }
 }
 
@@ -36,5 +46,22 @@ mod tests {
 
         assert_abs_diff_eq!(point.x(), 222650.79679758527, epsilon = 1.0e-10);
         assert_abs_diff_eq!(point.y(), 110642.22941193319, epsilon = 1.0e-10);
+    }
+
+    #[test]
+    fn transforms_multi_point() {
+        let mut multi_point: MultiPoint = (0..10)
+            .map(|_| Point::from((2.0f64.to_radians(), 1.0f64.to_radians())))
+            .collect();
+
+        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
+        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
+
+        transform(&from, &to, &mut multi_point).unwrap();
+
+        multi_point.iter().for_each(|point| {
+            assert_abs_diff_eq!(point.x(), 222650.79679758527, epsilon = 1.0e-10);
+            assert_abs_diff_eq!(point.y(), 110642.22941193319, epsilon = 1.0e-10);
+        });
     }
 }

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -15,3 +15,26 @@ impl Transform for Point {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use approx::assert_abs_diff_eq;
+
+    use crate::{transform::transform, Proj};
+
+    use super::*;
+
+    #[test]
+    fn transforms_point() {
+        let mut point = Point::from((2.0f64.to_radians(), 1.0f64.to_radians()));
+
+        let from = Proj::from_proj_string("+proj=latlong +ellps=GRS80").unwrap();
+        let to = Proj::from_proj_string("+proj=etmerc +ellps=GRS80").unwrap();
+
+        transform(&from, &to, &mut point).unwrap();
+
+        assert_abs_diff_eq!(point.x(), 222650.79679758527, epsilon = 1.0e-10);
+        assert_abs_diff_eq!(point.y(), 110642.22941193319, epsilon = 1.0e-10);
+    }
+}

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -86,6 +86,31 @@ impl Transform for Triangle {
     }
 }
 
+impl Transform for Geometry {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        match self {
+            Geometry::Point(geometry) => geometry.transform_coordinates(f),
+            Geometry::Line(geometry) => geometry.transform_coordinates(f),
+            Geometry::LineString(geometry) => geometry.transform_coordinates(f),
+            Geometry::Polygon(geometry) => geometry.transform_coordinates(f),
+            Geometry::MultiPoint(geometry) => geometry.transform_coordinates(f),
+            Geometry::MultiLineString(geometry) => geometry.transform_coordinates(f),
+            Geometry::MultiPolygon(geometry) => geometry.transform_coordinates(f),
+            Geometry::Rect(geometry) => geometry.transform_coordinates(f),
+            Geometry::Triangle(geometry) => geometry.transform_coordinates(f),
+            Geometry::GeometryCollection(geometry) => geometry.transform_coordinates(f),
+        }
+    }
+}
+
+impl Transform for GeometryCollection {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        self.0
+            .iter_mut()
+            .try_for_each(|geometry| geometry.transform_coordinates(f))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -53,10 +53,13 @@ impl Transform for MultiLineString {
 
 impl Transform for Polygon {
     fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
-        self.exterior.transform_coordinates(f)?;
-        self.interiors
-            .iter_mut()
-            .try_for_each(|interior| interior.transform_coordinates(f))
+        self.try_exterior_mut(|exterior| exterior.transform_coordinates(f))?;
+        self.try_interiors_mut(|interiors| {
+            for interior in interiors {
+                interior.transform_coordinates(f)?
+            }
+            Ok(())
+        })
     }
 }
 

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -67,6 +67,17 @@ impl Transform for MultiPolygon {
     }
 }
 
+impl Transform for Rect {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
+        let (mut min, mut max) = (self.min(), self.max());
+        min.transform_coordinates(f)?;
+        max.transform_coordinates(f)?;
+        self.set_min(min);
+        self.set_max(max);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use approx::assert_abs_diff_eq;
@@ -151,6 +162,14 @@ mod tests {
         interiors.into_iter().for_each(|line_string| {
             assert_cord_eq(COORD_1, line_string.0[0]);
         })
+    }
+
+    #[test]
+    fn transforms_rect() {
+        let mut rect = Rect::new(-COORD_0, COORD_0);
+        transform_helper(&mut rect);
+        assert_cord_eq(-COORD_1, rect.min());
+        assert_cord_eq(COORD_1, rect.max());
     }
 
     fn transform_helper<T: Transform>(geometry: &mut T) {

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -1,0 +1,17 @@
+use geo_types::Point;
+
+use crate::transform::Transform;
+
+impl Transform for Point {
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> crate::errors::Result<()>
+    where
+        F: FnMut(f64, f64, f64) -> crate::errors::Result<(f64, f64, f64)>,
+    {
+        let mut xy = (self.0.x, self.0.y);
+        (&mut xy).transform_coordinates(f)?;
+        self.set_x(xy.0);
+        self.set_y(xy.1);
+
+        Ok(())
+    }
+}

--- a/src/adaptors/geo_types.rs
+++ b/src/adaptors/geo_types.rs
@@ -1,12 +1,12 @@
 use geo_types::geometry::*;
 
-use crate::{errors::Result, transform::Transform};
+use crate::{
+    errors::Result,
+    transform::{Transform, TransformClosure},
+};
 
 impl Transform for Coord {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         let mut xy = (self.x, self.y);
         (&mut xy).transform_coordinates(f)?;
         *self = Coord::from(xy);
@@ -15,29 +15,20 @@ impl Transform for Coord {
 }
 
 impl Transform for Point {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         self.0.transform_coordinates(f)
     }
 }
 
 impl Transform for MultiPoint {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         self.iter_mut()
             .try_for_each(|point| point.transform_coordinates(f))
     }
 }
 
 impl Transform for Line {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         let (mut start, mut end) = self.points();
         start.transform_coordinates(f)?;
         end.transform_coordinates(f)?;
@@ -47,10 +38,7 @@ impl Transform for Line {
 }
 
 impl Transform for LineString {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
-    {
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()> {
         self.coords_mut()
             .try_for_each(|coord| coord.transform_coordinates(f))
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -9,6 +9,10 @@ use crate::geocent::{geocentric_to_geodetic, geodetic_to_geocentric};
 use crate::math::adjlon;
 use crate::math::consts::{EPS_12, FRAC_PI_2};
 use crate::proj::{Axis, Proj, ProjType};
+
+pub trait TransformClosure: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)> {}
+impl<F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>> TransformClosure for F {}
+
 ///
 /// Transform trait
 ///
@@ -24,7 +28,7 @@ use crate::proj::{Axis, Proj, ProjType};
 /// Single point transform example:
 ///
 /// ```rust
-/// use proj4rs::transform::{transform, Transform};
+/// use proj4rs::transform::{transform, Transform, TransformClosure};
 /// use proj4rs::errors::Result;
 ///
 /// pub struct Point {
@@ -34,9 +38,7 @@ use crate::proj::{Axis, Proj, ProjType};
 /// }
 ///
 /// impl Transform for Point {
-///     fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-///     where
-///         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
+///     fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()>
 ///     {
 ///         f(self.x, self.y, self.z).map(|(x, y, z)| {
 ///             self.x = x;
@@ -48,9 +50,7 @@ use crate::proj::{Axis, Proj, ProjType};
 /// ```
 ///
 pub trait Transform {
-    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
-    where
-        F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>;
+    fn transform_coordinates<F: TransformClosure>(&mut self, f: &mut F) -> Result<()>;
 }
 
 // ------------------

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -34,7 +34,7 @@ use crate::proj::{Axis, Proj, ProjType};
 /// }
 ///
 /// impl Transform for Point {
-///     fn transform_coordinates<F>(&mut self, mut f: F) -> Result<()>
+///     fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
 ///     where
 ///         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>,
 ///     {
@@ -48,7 +48,7 @@ use crate::proj::{Axis, Proj, ProjType};
 /// ```
 ///
 pub trait Transform {
-    fn transform_coordinates<F>(&mut self, f: F) -> Result<()>
+    fn transform_coordinates<F>(&mut self, f: &mut F) -> Result<()>
     where
         F: FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>;
 }
@@ -118,7 +118,7 @@ where
         return Ok(());
     }
 
-    points.transform_coordinates(|x, y, z| Datum::transform(src_datum, dst_datum, x, y, z))
+    points.transform_coordinates(&mut |x, y, z| Datum::transform(src_datum, dst_datum, x, y, z))
 }
 // ---------------------------------
 // Projected to geographic (inverse)
@@ -133,8 +133,9 @@ where
             if p.geoc() {
                 let rone_es = p.ellipsoid().rone_es;
                 // Geocentric latitude => geodetic latitude
-                points
-                    .transform_coordinates(|lam, phi, z| Ok((lam, (rone_es * phi.tan()).atan(), z)))
+                points.transform_coordinates(&mut |lam, phi, z| {
+                    Ok((lam, (rone_es * phi.tan()).atan(), z))
+                })
             } else {
                 Ok(())
             }
@@ -150,7 +151,7 @@ where
 
             // Input points are cartesians
             // proj4 source: pj_inv.c
-            points.transform_coordinates(|x, y, z| {
+            points.transform_coordinates(&mut |x, y, z| {
                 // Inverse project
                 let (mut lam, phi, z) = proj.inverse(
                     // descale and de-offset
@@ -180,7 +181,7 @@ where
         ProjType::Latlong => {
             if p.geoc() {
                 let one_es = p.ellipsoid().one_es;
-                points.transform_coordinates(|lam, phi, z| {
+                points.transform_coordinates(&mut |lam, phi, z| {
                     // Geodetic latitude to geocentric latitude
                     Ok(if (phi.abs() - FRAC_PI_2).abs() > EPS_12 {
                         (lam, (one_es * phi.tan()).atan(), z)
@@ -206,7 +207,7 @@ where
 
             // Input points are geographic
             // proj4 source: pj_fwd.c
-            points.transform_coordinates(|lam, phi, z| {
+            points.transform_coordinates(&mut |lam, phi, z| {
                 // Over range check
                 let t = phi.abs() - FRAC_PI_2;
                 if t > EPS_12 || lam.abs() > 10. {
@@ -265,21 +266,20 @@ where
 
     if fac != 1.0 {
         match dir {
-            Forward => points.transform_coordinates(|x, y, z| {
+            Forward => points.transform_coordinates(&mut |x, y, z| {
                 geodetic_to_geocentric(x, y, z, a, es).map(|(x, y, z)| (x * fac, y * fac, z * fac))
             }),
-            Inverse => points.transform_coordinates(|x, y, z| {
+            Inverse => points.transform_coordinates(&mut |x, y, z| {
                 geocentric_to_geodetic(x * fac, y * fac, z * fac, a, es, b)
             }),
         }
     } else {
         match dir {
             Forward => {
-                points.transform_coordinates(|x, y, z| geodetic_to_geocentric(x, y, z, a, es))
+                points.transform_coordinates(&mut |x, y, z| geodetic_to_geocentric(x, y, z, a, es))
             }
-            Inverse => {
-                points.transform_coordinates(|x, y, z| geocentric_to_geodetic(x, y, z, a, es, b))
-            }
+            Inverse => points
+                .transform_coordinates(&mut |x, y, z| geocentric_to_geodetic(x, y, z, a, es, b)),
         }
     }
 }
@@ -297,7 +297,7 @@ where
         if dir == Forward {
             pm = -pm;
         }
-        points.transform_coordinates(|x, y, z| Ok((x + pm, y, z)))
+        points.transform_coordinates(&mut |x, y, z| Ok((x + pm, y, z)))
     }
 }
 // ---------------------
@@ -319,7 +319,7 @@ where
 
 // Normalize axis
 fn normalize_axis<P: Transform + ?Sized>(axis: &Axis, points: &mut P) -> Result<()> {
-    points.transform_coordinates(|x, y, z| {
+    points.transform_coordinates(&mut |x, y, z| {
         let (mut x_out, mut y_out, mut z_out) = (x, y, z);
         axis.iter().enumerate().for_each(|(i, axe)| {
             let value = match i {
@@ -345,7 +345,7 @@ fn normalize_axis<P: Transform + ?Sized>(axis: &Axis, points: &mut P) -> Result<
 
 // Denormalize axis
 fn denormalize_axis<P: Transform + ?Sized>(axis: &Axis, points: &mut P) -> Result<()> {
-    points.transform_coordinates(|x, y, z| {
+    points.transform_coordinates(&mut |x, y, z| {
         let (mut x_out, mut y_out, mut z_out) = (x, y, z);
         axis.iter().enumerate().for_each(|(i, axe)| {
             let value = match axe {
@@ -386,7 +386,7 @@ where
     };
 
     if fac != 1.0 {
-        points.transform_coordinates(|x, y, z| Ok((x, y, z * fac)))
+        points.transform_coordinates(&mut |x, y, z| Ok((x, y, z * fac)))
     } else {
         Ok(())
     }


### PR DESCRIPTION
From the CHANGELOG:

### Added
* `Transform` implementations.
    - Implement for a 2-tuple.  
    - Implement for the `geo-types` geometries, them being placed behind a `geo-types` feature flag.

### Changed

* `Transform` trait signature.
    - Alias `FnMut(f64, f64, f64) -> Result<(f64, f64, f64)>` behind a `TransformClosure`
    - `transform_coordinates()` takes a mutable reference to `f`, making it easier to layer `Transform` implementations.
