### PR TITLE
Fix geo-types optional dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 thiserror = "1.0"
 lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true  }
-geo-types = "0.7.12"
+geo-types = { version = "0.7.12", optional = true }
 
 [dev-dependencies]
 approx = "0.5"


### PR DESCRIPTION
```
Caused by:
  failed to load source for dependency `proj4rs`

Caused by:
  Unable to update https://github.com/3liz/proj4rs

Caused by:
  failed to parse manifest at `./cargo/git/checkouts/proj4rs-092a0819c218316e/86d5ae3/Cargo.toml`

Caused by:
  feature `geo-types` includes `dep:geo-types`, but `geo-types` is not an optional dependency
  A non-optional dependency of the same name is defined; consider adding `optional = true` to its definition.
```

Pretty sure this was unintentionally caused by https://github.com/3liz/proj4rs/pull/10