### PR TITLE
fix: remove wee_alloc as it's unmaintained

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ exclude = [
 
 [dependencies]
 crs-definitions = { version = "0.3", optional = true, default-features = false, features = ["proj4"] }
-thiserror = "1.0"
-lazy_static = { version = "1", optional = true }
-log = { version = "0.4", optional = true  }
 geo-types = { version = "0.7.12", optional = true }
+lazy_static = { version = "1", optional = true }
+log = { version = "0.4", optional = true }
+thiserror = "1.0"
 
 [dev-dependencies]
 approx = "0.5"
+clap = { version = "4", features = ["derive"] }
 criterion = { version = "0.5" }
 env_logger = "0.10"
-clap = { version = "4", features=["derive"] }
 log = "0.4"
 
 [profile.release]
@@ -55,7 +55,6 @@ proj4js-compat = []
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
-wee_alloc = "0.4"
 console_log = "1.0"
 
 [[bench]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!   mostly from js app (at least with OpenLayer).
 //! * **multi-thread**: Support for multi-thread with NAD Grid processing, this is activated by
 //!   default and disabled when compiling for WASM.
-//! * **crs-definitions**: Support for initializing projections from EPSG codes with the 
+//! * **crs-definitions**: Support for initializing projections from EPSG codes with the
 //! [crs_definitions](https://docs.rs/crs-definitions/latest/crs_definitions/) crate.
 //!
 //! ## WKT Support
@@ -116,10 +116,6 @@ mod wasm;
 
 #[cfg(test)]
 mod tests;
-
-#[cfg(target_arch = "wasm32")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
 // log for logging (optional).
 #[cfg(feature = "logging")]


### PR DESCRIPTION
<!-- Add "fix" in front of # if it fixes the ticket or do nothing to only mention it -->
`wee_alloc` is no longer maintained - see rustwasm/wee_alloc#107 switch to the default Rust standard allocator.
