### PR TITLE
Remove lazy_static dependency

### DIFF
--- a/proj4rs/Cargo.toml
+++ b/proj4rs/Cargo.toml
@@ -25,7 +25,6 @@ exclude = [
 thiserror = "2.0"
 crs-definitions = { version = "0.3", optional = true, default-features = false, features = ["proj4"] }
 geo-types = { version = "0.7.12", optional = true }
-lazy_static = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 proj4rs-geodesic = { version = "~0.1", optional = true }
 
@@ -48,7 +47,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["multi-thread", "binaries"]
 binaries = []
-multi-thread = ["lazy_static"]
+multi-thread = []
 geo-types = ["dep:geo-types"]
 logging = ["log"]
 local_tests = []


### PR DESCRIPTION
`CATALOG` can be constructed at compile-time instead.